### PR TITLE
Remove borders from <code> inside <pre>.

### DIFF
--- a/freshrss.tera
+++ b/freshrss.tera
@@ -673,6 +673,10 @@ li.item.active {
   padding: 2px 5px;
 }
 
+.content pre code {
+  border: none;
+}
+
 .content blockquote {
   margin: 0;
   padding: 5px 20px;

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -666,6 +666,10 @@ li.item.active {
   padding: 2px 5px;
 }
 
+.content pre code {
+  border: none;
+}
+
 .content blockquote {
   margin: 0;
   padding: 5px 20px;

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -666,6 +666,10 @@ li.item.active {
   padding: 2px 5px;
 }
 
+.content pre code {
+  border: none;
+}
+
 .content blockquote {
   margin: 0;
   padding: 5px 20px;

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -666,6 +666,10 @@ li.item.active {
   padding: 2px 5px;
 }
 
+.content pre code {
+  border: none;
+}
+
 .content blockquote {
   margin: 0;
   padding: 5px 20px;

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -666,6 +666,10 @@ li.item.active {
   padding: 2px 5px;
 }
 
+.content pre code {
+  border: none;
+}
+
 .content blockquote {
   margin: 0;
   padding: 5px 20px;


### PR DESCRIPTION
This change removes borders from `<code>` blocks that are already inside `<pre>` tags.

## Before
![before](https://github.com/user-attachments/assets/10438d96-96dd-4197-9b95-4fb75171cf2f)

## After
![after](https://github.com/user-attachments/assets/e4e2264c-00e4-4a8e-bf75-0c4b3505d598)
